### PR TITLE
Implement shared functions for getting common RAM addresses

### DIFF
--- a/patches/shared/includes/ram_getters.asm
+++ b/patches/shared/includes/ram_getters.asm
@@ -1,0 +1,29 @@
+@asar 1.50
+@includefrom "../shared.asm"
+
+; This file is included by shared.asm and should not be included directly
+
+!shared_asm_included ?= 0
+
+if !shared_asm_included == 0
+
+	error "Trying to include 'ram_getters.asm' directly, which is meant to be included from 'shared.asm' only."
+	
+else
+
+	!ram_getters_asm_included ?= 0
+
+	if !ram_getters_asm_included == 0
+		!ram_getters_asm_included = 1
+
+		; Gets the RAM address corresponding to the supplied X and Y status bar coordinates
+		; or $00, if the status bar coordinate doesn’t have a corresponding address.
+		; ==========================================================================
+		; TODO: Add support for Super Status Bar
+		function get_status_ram(X, Y) = remap_ram(\
+			select(logical_and(equal(Y,$2),logical_and(greater_equal(X,$2),less(X,$1E))),X-$2+$0EF9,\	; if (y == $2 && x >= $2 && x < $1E) return X-$2+$0EF9;
+			select(logical_and(equal(Y,$3),logical_and(greater_equal(X,$3),less(X,$1E))),X-$3+$0F15,\	; if (y == $3 && x >= $3 && x < $1E) return X-$3+$0F15;
+		$0)))
+
+	endif
+endif

--- a/patches/shared/shared.asm
+++ b/patches/shared/shared.asm
@@ -364,5 +364,6 @@ if !shared_asm_included == 0
 	; Includes
 	
 	incsrc includes/print_implementation.asm
+	incsrc includes/ram_getters.asm
 		
 endif


### PR DESCRIPTION
Currently, this only supports getting Status Bar RAM addresses and doesn’t yet support Super Status Bar Advanced, but this will be helpful for #1 (specifically for the [RPG-Styled HP and MP Counter](https://www.smwcentral.net/?p=section&a=details&id=12585)’s modified Status Bar).

This function was originally coded for my own use in my own ASM hack that I showcased screenshots from in the SMW Central discord server a few times based off a similar function for getting the Overworld border RAM address from the [Overworld Border Plus](https://www.smwcentral.net/?p=section&a=details&id=15222) patch.