### PR TITLE
chore: Add `.gitattributes`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,14 @@
+# Set the default behaviour, in case people don't have core.autocrlf set.
+*	text=lf
+
+# Explicitly declare text files you want to always be normalized and converted
+# to native line endings on checkout.
+*.asm	text
+*.cfg	text
+.gitattributes	text
+.gitignore	text
+.gitmodules	text
+
+# Denote all files that are truly binary and should not be modified.
+*.bin	binary
+*.sfc	binary


### PR DESCRIPTION
This adds the&nbsp;`.gitattributes` file to&nbsp;ensure that line&nbsp;ending issues like the&nbsp;one in&nbsp;https://github.com/RPGHacker/SMW-Workspace/pull/20 don’t happen again.